### PR TITLE
Add initial Spring Boot payment service implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # SWEliteProject
+
+헥토의 "Spring Cloud 모듈을 활용한 MSA 개발" 프로젝트 저장소입니다. 전체 개발 범위, 요구사항, 아키텍처, 일정, 품질 전략 등은 [`docs/development-plan.md`](docs/development-plan.md)에 정리되어 있습니다. 작업을 시작하기 전에 반드시 해당 문서를 확인하세요.
+
+## Payment 서비스 (초기 버전)
+
+### 로컬 실행
+
+```bash
+mvn spring-boot:run
+```
+
+### 테스트 실행
+
+```bash
+mvn test
+```
+
+### 주요 엔드포인트
+
+| 메서드 | 경로 | 설명 |
+| --- | --- | --- |
+| `POST` | `/payments/authorize` | 결제 승인 요청 (멱등성 키로 중복 방지) |
+| `POST` | `/payments/capture/{paymentId}` | 승인 건 매입 처리 |
+| `POST` | `/payments/refund/{paymentId}` | 매입 완료 건 환불 |
+
+각 API의 요청/응답 스키마는 향후 OpenAPI 문서로 제공될 예정입니다. 현재는 `src/test/java/com/hecto/payments/paymentservice/PaymentControllerTest.java`를 참고하세요.

--- a/docs/development-plan.md
+++ b/docs/development-plan.md
@@ -1,0 +1,112 @@
+# 헥토 Spring Cloud 기반 MSA 개발 계획
+
+## 1. 프로젝트 목표 및 타당성 조사
+본 프로젝트는 단순 기능 검증을 넘어 핀테크 서비스 수준의 대규모 트랜잭션 처리와 데이터 정합성 보장을 학습·실습하기 위한 교육용 프로젝트다. 헥토의 신규 채용 과정과 연계하여, 실제 현업 투입이 가능한 백엔드 개발자로 성장하는 것을 목표로 한다. 성능 목표는 Gatling 기반 부하 테스트로 검증하며, 100TPS 환경에서 p95 응답 시간이 500ms 이하임을 반복적으로 입증한다. KT Cloud 환경에 마이크로서비스 아키텍처(MSA) 기반의 모의 결제 백엔드 시스템을 배포하고 운영한다.
+
+### 1.1 타당성 조사
+- **기술**: Spring Cloud 기반 MSA, Kafka, Redis, Outbox 패턴은 산업 현장에서 검증된 스택이며 KT Cloud IaaS에서 Docker 배포 가능성이 높다.
+- **성능**: 캐싱과 비동기 처리로 100TPS, p95 500ms 목표가 합리적이다. I/O 지연이 병목이므로 DB 인덱스 전략, 연결 풀, 배치 크기 튜닝이 핵심이다.
+- **운영**: Prometheus + Grafana + OpenTelemetry로 관측성을 확보하고 DLQ 재처리로 운영 리스크를 완화한다. Jenkins로 롤백 시간을 단축한다.
+- **보안/규제**: 실제 금융 정보를 저장하지 않으며 HMAC, 마스킹, 비밀 관리로 기본 준수 범위를 충족한다.
+- **비용**: 관리형 MariaDB/Redis 활용 시 초기 구축/운영 비용을 절감할 수 있으며 Auto Scale은 단계적 비용 집행이 가능하다.
+- **리스크 및 대응**: Kafka 장애 시 Outbox+재시도+DLQ로 유실 0% 설계, 성능 미달 시 캐시 확대/파티션 증설/비동기 전환 확대, 일정 지연 시 정산·대사 기능 제외로 범위 축소가 가능하다.
+- **ROI**: p95 2.5초 → 500ms 개선 가정 시 고객 대기 시간이 대폭 단축되고 동일 인프라 대비 처리량 증가로 VM 수 감소가 가능하다.
+
+## 2. 개발 범위
+### 포함 기능
+- **핵심 API**: 결제 승인, 매입, 환불을 우선 구현하고 정산/대사 기능은 확장 설계로 제시한다.
+- **배치 작업**: 특정 기간 거래를 집계하여 정산 데이터를 생성한다.
+- **시스템 안정성/효율**:
+  - Redis를 활용한 캐싱 및 트래픽 제어
+  - Kafka를 이용한 비동기 메시지 처리
+  - Jenkins CI/CD 파이프라인 구축
+  - Prometheus + Grafana 기반 모니터링
+- **기본 보안**: HMAC, 개인정보 마스킹, 비밀 키 분리 적용
+
+### 제외 기능
+- 실제 PG 및 은행 시스템 연동, 카드 정보 저장, PCI-DSS 문서 작업, 정산·대사 기능의 실제 구현(설계만 제시)
+
+## 3. 요구사항
+### 기능적 요구사항
+- **결제 승인**: 파라미터 검증, 멱등성 처리(409), `REQUESTED` 상태 저장
+- **결제 매입**: `REQUESTED` 건만 매입 가능, 상태 `COMPLETED`, 이중부기 원장 기록
+- **결제 환불**: `COMPLETED` 건만 환불, 환불 트랜잭션 생성, 상태 `REFUNDED`, 역원장 기록
+- **정산 배치**: `COMPLETED` 거래 집계 및 `settlement_batch` 기록 생성
+- **대사 기능(확장)**: CSV 업로드, 데이터 매칭, 불일치 처리, DLQ 전송, 재처리 API
+
+### 비기능적 요구사항
+- **성능**: p95 ≤ 500ms, 100TPS 처리
+- **안정성/가용성**: 서비스 장애 격리, Outbox 패턴으로 데이터 유실 0%
+- **데이터 정합성**: 이중부기, 멱등성 보장
+- **확장성**: Stateless 서비스로 수평 확장
+- **보안**: HMAC 검증, 민감 정보 마스킹, 비밀 정보 분리
+- **관측성**: 표준화된 로깅, Prometheus Metrics, Grafana 대시보드, (확장) OpenTelemetry 트레이싱
+
+### 요구사항 추적 매트릭스
+| ID | 설명 | 수용 기준 | 검증 방법 |
+| --- | --- | --- | --- |
+| FR-001 | 결제 승인 API 제공 | 200 OK, DB에 `REQUESTED` 상태 저장 | 단위/통합 테스트 |
+| FR-002 | 정산 배치 기능 | 5,000건 1분 내 처리 | 성능 테스트 |
+| NFR-001 | 응답 지연 | p95 ≤ 500ms | 부하 테스트 |
+| NFR-002 | 데이터 유실 방지 | 장애 시 데이터 유실 0% | 장애 시뮬레이션 |
+
+## 4. 시스템 아키텍처
+### 서비스 구성
+- API Gateway → Payment → Settlement → Reconciliation → Notify(확장)
+- 공통 인프라: Service Registry(Eureka/Consul), Config Server, MariaDB, Redis, Kafka(+DLQ), Prometheus, Grafana
+
+### 데이터 흐름
+클라이언트 → API Gateway → Payment(핵심 처리) → DB → Outbox → Kafka → 후속 서비스. Outbox 패턴으로 이벤트 발행 안정성을 확보한다.
+
+### 배포 아키텍처
+KT Cloud VM 1~2대에 Docker로 배포(서비스, Kafka, Redis, MariaDB, Jenkins). Managed DB/Redis 사용으로 운영 부담을 줄인다.
+
+## 5. 테이블 및 API 명세
+### 핵심 테이블
+`payment`, `ledger_entry`, `outbox_event`, `idem_response_cache`, `settlement_batch`, `settlement_item`, `recon_file`, `recon_item` (확장). SQL 스키마는 문서 본문 참고.
+
+### 주요 토픽/캐시 키
+- Redis: rate limiting, 멱등성 캐시, 분산 락
+- Kafka: `payment.authorized`, `payment.captured`, `payment.refunded`, (확장) `recon.unmatched`, `settlement.closed`
+
+### API 예시
+- `POST /payments/authorize`
+- `POST /payments/capture/{paymentId}`
+- `POST /payments/refund/{paymentId}`
+- `POST /payments/upload` (확장)
+
+요청/응답 예시는 문서 본문 참고.
+
+## 6. 기술 스택
+- **언어/프레임워크**: Java, Spring Boot, Spring Cloud
+- **DB**: MariaDB (JPA/JDBC, 필요 시 Flyway)
+- **캐시**: Redis
+- **메시징**: Kafka
+- **인프라/자동화**: Jenkins, Docker, Testcontainers
+- **테스트/모니터링**: Gatling, Prometheus, Grafana
+
+## 7. 상세 시나리오
+- 정상 결제/매입, 네트워크 오류 멱등 처리, 대사 프로세스, Kafka 장애 복구 시나리오를 정의한다.
+
+## 8. 개발 일정 및 관리 프로세스
+8주 계획(주차별 목표, 산출물, 완료 조건)과 전형적인 개발 프로세스(계획→분석→설계→구현→테스트→종료)를 명시한다.
+
+## 9. FE & BE 구성 방안
+- **FE**: Thymeleaf 기반 최소 UI(결제 테스트, 대사 업로드, 관리자 대시보드, Grafana 연동)
+- **BE**: MSA 원칙(Single Responsibility, Loose Coupling, DB per Service) 준수, Kafka 기반 비동기 통신
+
+## 10. 기대 효과 및 기여 방안
+핀테크 핵심 역량(대용량 트랜잭션, 정합성, 안정성) 학습 및 DevOps 역량 확보로 헥토와 같은 기업에 기여 가능.
+
+## 11. 구현 계획 및 마일스톤
+8주 일정의 상세 마일스톤을 정의(산출물, 완료 조건, 위험 및 완화 조치 포함).
+
+## 12. 품질보증/테스트 전략
+단위/통합/부하/보안/회귀 테스트 전략, 도구, 수용 기준 및 예시 테스트 케이스 매트릭스를 제공한다.
+
+## 13. 애플리케이션 및 배포 아키텍처
+MSA 구성요소와 KT Cloud 배포 전략을 시각화/설명한다.
+
+## 14. 리스크 관리 및 대응 전략
+주요 리스크, 평가(가능성×영향도), 대응 전략, 모니터링 체계를 정리한다.
+

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,82 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.hecto.payments</groupId>
+    <artifactId>payment-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>payment-service</name>
+    <description>Payment service for mock PG backend</description>
+
+    <properties>
+        <java.version>21</java.version>
+        <spring.boot.version>3.3.5</spring.boot.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-dependencies</artifactId>
+                <version>${spring.boot.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                    <release>${java.version}</release>
+                    <compilerArgs>
+                        <arg>-parameters</arg>
+                    </compilerArgs>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/hecto/payments/paymentservice/PaymentServiceApplication.java
+++ b/src/main/java/com/hecto/payments/paymentservice/PaymentServiceApplication.java
@@ -1,0 +1,12 @@
+package com.hecto.payments.paymentservice;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class PaymentServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(PaymentServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/domain/LedgerEntry.java
+++ b/src/main/java/com/hecto/payments/paymentservice/domain/LedgerEntry.java
@@ -1,0 +1,73 @@
+package com.hecto.payments.paymentservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "ledger_entry")
+public class LedgerEntry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "entry_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "payment_id", nullable = false)
+    private Payment payment;
+
+    @Column(name = "debit_account", nullable = false, length = 64)
+    private String debitAccount;
+
+    @Column(name = "credit_account", nullable = false, length = 64)
+    private String creditAccount;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    protected LedgerEntry() {
+    }
+
+    public LedgerEntry(Payment payment, String debitAccount, String creditAccount, Long amount) {
+        this.payment = payment;
+        this.debitAccount = debitAccount;
+        this.creditAccount = creditAccount;
+        this.amount = amount;
+        this.occurredAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Payment getPayment() {
+        return payment;
+    }
+
+    public String getDebitAccount() {
+        return debitAccount;
+    }
+
+    public String getCreditAccount() {
+        return creditAccount;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public Instant getOccurredAt() {
+        return occurredAt;
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/domain/OutboxEvent.java
+++ b/src/main/java/com/hecto/payments/paymentservice/domain/OutboxEvent.java
@@ -1,0 +1,82 @@
+package com.hecto.payments.paymentservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "outbox_event", indexes = {
+        @Index(name = "ix_published_created", columnList = "published, created_at")
+})
+public class OutboxEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "event_id")
+    private Long id;
+
+    @Column(name = "aggregate_type", nullable = false, length = 32)
+    private String aggregateType;
+
+    @Column(name = "aggregate_id", nullable = false)
+    private Long aggregateId;
+
+    @Column(name = "event_type", nullable = false, length = 32)
+    private String eventType;
+
+    @Lob
+    @Column(nullable = false)
+    private String payload;
+
+    @Column(nullable = false)
+    private boolean published;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    protected OutboxEvent() {
+    }
+
+    public OutboxEvent(String aggregateType, Long aggregateId, String eventType, String payload) {
+        this.aggregateType = aggregateType;
+        this.aggregateId = aggregateId;
+        this.eventType = eventType;
+        this.payload = payload;
+        this.published = false;
+        this.createdAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getAggregateType() {
+        return aggregateType;
+    }
+
+    public Long getAggregateId() {
+        return aggregateId;
+    }
+
+    public String getEventType() {
+        return eventType;
+    }
+
+    public String getPayload() {
+        return payload;
+    }
+
+    public boolean isPublished() {
+        return published;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/domain/Payment.java
+++ b/src/main/java/com/hecto/payments/paymentservice/domain/Payment.java
@@ -1,0 +1,113 @@
+package com.hecto.payments.paymentservice.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+@Entity
+@Table(name = "payment", indexes = {
+        @Index(name = "ix_status_time", columnList = "status, requested_at"),
+        @Index(name = "ix_merchant_time", columnList = "merchant_id, requested_at")
+}, uniqueConstraints = {
+        @jakarta.persistence.UniqueConstraint(name = "uk_merchant_idem", columnNames = {"merchant_id", "idempotency_key"})
+})
+public class Payment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payment_id")
+    private Long id;
+
+    @Column(name = "merchant_id", nullable = false, length = 32)
+    private String merchantId;
+
+    @Column(nullable = false)
+    private Long amount;
+
+    @Column(nullable = false, length = 3)
+    private String currency;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private PaymentStatus status;
+
+    @Column(name = "idempotency_key", nullable = false, length = 64)
+    private String idempotencyKey;
+
+    @Column(name = "requested_at", nullable = false)
+    private Instant requestedAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    protected Payment() {
+    }
+
+    public Payment(String merchantId, Long amount, String currency, PaymentStatus status, String idempotencyKey) {
+        this.merchantId = merchantId;
+        this.amount = amount;
+        this.currency = currency;
+        this.status = status;
+        this.idempotencyKey = idempotencyKey;
+        this.requestedAt = Instant.now();
+        this.updatedAt = this.requestedAt;
+    }
+
+    public void markRequested() {
+        this.status = PaymentStatus.REQUESTED;
+        touch();
+    }
+
+    public void markCompleted() {
+        this.status = PaymentStatus.COMPLETED;
+        touch();
+    }
+
+    public void markRefunded() {
+        this.status = PaymentStatus.REFUNDED;
+        touch();
+    }
+
+    public void touch() {
+        this.updatedAt = Instant.now();
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getMerchantId() {
+        return merchantId;
+    }
+
+    public Long getAmount() {
+        return amount;
+    }
+
+    public String getCurrency() {
+        return currency;
+    }
+
+    public PaymentStatus getStatus() {
+        return status;
+    }
+
+    public String getIdempotencyKey() {
+        return idempotencyKey;
+    }
+
+    public Instant getRequestedAt() {
+        return requestedAt;
+    }
+
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/domain/PaymentStatus.java
+++ b/src/main/java/com/hecto/payments/paymentservice/domain/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.hecto.payments.paymentservice.domain;
+
+public enum PaymentStatus {
+    REQUESTED,
+    COMPLETED,
+    REFUNDED,
+    CANCELLED
+}

--- a/src/main/java/com/hecto/payments/paymentservice/exception/DuplicateRequestException.java
+++ b/src/main/java/com/hecto/payments/paymentservice/exception/DuplicateRequestException.java
@@ -1,0 +1,16 @@
+package com.hecto.payments.paymentservice.exception;
+
+import com.hecto.payments.paymentservice.domain.Payment;
+
+public class DuplicateRequestException extends RuntimeException {
+    private final Payment existingPayment;
+
+    public DuplicateRequestException(Payment existingPayment) {
+        super("Idempotency key already used");
+        this.existingPayment = existingPayment;
+    }
+
+    public Payment getExistingPayment() {
+        return existingPayment;
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/exception/InvalidPaymentStateException.java
+++ b/src/main/java/com/hecto/payments/paymentservice/exception/InvalidPaymentStateException.java
@@ -1,0 +1,9 @@
+package com.hecto.payments.paymentservice.exception;
+
+import com.hecto.payments.paymentservice.domain.PaymentStatus;
+
+public class InvalidPaymentStateException extends RuntimeException {
+    public InvalidPaymentStateException(Long paymentId, PaymentStatus expected, PaymentStatus actual) {
+        super("Payment %d expected in state %s but was %s".formatted(paymentId, expected, actual));
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/exception/MerchantMismatchException.java
+++ b/src/main/java/com/hecto/payments/paymentservice/exception/MerchantMismatchException.java
@@ -1,0 +1,7 @@
+package com.hecto.payments.paymentservice.exception;
+
+public class MerchantMismatchException extends RuntimeException {
+    public MerchantMismatchException(Long paymentId) {
+        super("Payment %d does not belong to the provided merchant".formatted(paymentId));
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/exception/PaymentNotFoundException.java
+++ b/src/main/java/com/hecto/payments/paymentservice/exception/PaymentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.hecto.payments.paymentservice.exception;
+
+public class PaymentNotFoundException extends RuntimeException {
+    public PaymentNotFoundException(Long paymentId) {
+        super("Payment %d not found".formatted(paymentId));
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/repository/LedgerEntryRepository.java
+++ b/src/main/java/com/hecto/payments/paymentservice/repository/LedgerEntryRepository.java
@@ -1,0 +1,7 @@
+package com.hecto.payments.paymentservice.repository;
+
+import com.hecto.payments.paymentservice.domain.LedgerEntry;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LedgerEntryRepository extends JpaRepository<LedgerEntry, Long> {
+}

--- a/src/main/java/com/hecto/payments/paymentservice/repository/OutboxEventRepository.java
+++ b/src/main/java/com/hecto/payments/paymentservice/repository/OutboxEventRepository.java
@@ -1,0 +1,7 @@
+package com.hecto.payments.paymentservice.repository;
+
+import com.hecto.payments.paymentservice.domain.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, Long> {
+}

--- a/src/main/java/com/hecto/payments/paymentservice/repository/PaymentRepository.java
+++ b/src/main/java/com/hecto/payments/paymentservice/repository/PaymentRepository.java
@@ -1,0 +1,9 @@
+package com.hecto.payments.paymentservice.repository;
+
+import com.hecto.payments.paymentservice.domain.Payment;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+    Optional<Payment> findByMerchantIdAndIdempotencyKey(String merchantId, String idempotencyKey);
+}

--- a/src/main/java/com/hecto/payments/paymentservice/service/PaymentCommandService.java
+++ b/src/main/java/com/hecto/payments/paymentservice/service/PaymentCommandService.java
@@ -1,0 +1,127 @@
+package com.hecto.payments.paymentservice.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.hecto.payments.paymentservice.domain.LedgerEntry;
+import com.hecto.payments.paymentservice.domain.OutboxEvent;
+import com.hecto.payments.paymentservice.domain.Payment;
+import com.hecto.payments.paymentservice.domain.PaymentStatus;
+import com.hecto.payments.paymentservice.exception.DuplicateRequestException;
+import com.hecto.payments.paymentservice.exception.InvalidPaymentStateException;
+import com.hecto.payments.paymentservice.exception.PaymentNotFoundException;
+import com.hecto.payments.paymentservice.exception.MerchantMismatchException;
+import com.hecto.payments.paymentservice.repository.LedgerEntryRepository;
+import com.hecto.payments.paymentservice.repository.OutboxEventRepository;
+import com.hecto.payments.paymentservice.repository.PaymentRepository;
+import jakarta.transaction.Transactional;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+
+@Service
+public class PaymentCommandService {
+
+    private final PaymentRepository paymentRepository;
+    private final LedgerEntryRepository ledgerEntryRepository;
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+
+    public PaymentCommandService(PaymentRepository paymentRepository,
+                                 LedgerEntryRepository ledgerEntryRepository,
+                                 OutboxEventRepository outboxEventRepository,
+                                 ObjectMapper objectMapper) {
+        this.paymentRepository = paymentRepository;
+        this.ledgerEntryRepository = ledgerEntryRepository;
+        this.outboxEventRepository = outboxEventRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    @Transactional
+    public Payment authorize(String merchantId, long amount, String currency, String idempotencyKey) {
+        paymentRepository.findByMerchantIdAndIdempotencyKey(merchantId, idempotencyKey)
+                .ifPresent(existing -> {
+                    throw new DuplicateRequestException(existing);
+                });
+
+        Payment payment = new Payment(merchantId, amount, currency.toUpperCase(), PaymentStatus.REQUESTED, idempotencyKey);
+        payment.markRequested();
+        Payment saved = paymentRepository.save(payment);
+
+        recordEvent(saved, "PAYMENT_AUTHORIZED", Map.of(
+                "paymentId", saved.getId(),
+                "merchantId", saved.getMerchantId(),
+                "amount", saved.getAmount(),
+                "currency", saved.getCurrency(),
+                "status", saved.getStatus().name()
+        ));
+        return saved;
+    }
+
+    @Transactional
+    public Payment capture(Long paymentId, String merchantId) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new PaymentNotFoundException(paymentId));
+
+        if (!payment.getMerchantId().equals(merchantId)) {
+            throw new MerchantMismatchException(paymentId);
+        }
+
+        if (payment.getStatus() != PaymentStatus.REQUESTED) {
+            throw new InvalidPaymentStateException(paymentId, PaymentStatus.REQUESTED, payment.getStatus());
+        }
+
+        payment.markCompleted();
+        Payment saved = paymentRepository.save(payment);
+
+        ledgerEntryRepository.save(new LedgerEntry(payment, "merchant_receivable", "cash", payment.getAmount()));
+
+        recordEvent(saved, "PAYMENT_CAPTURED", Map.of(
+                "paymentId", saved.getId(),
+                "merchantId", saved.getMerchantId(),
+                "amount", saved.getAmount(),
+                "status", saved.getStatus().name()
+        ));
+        return saved;
+    }
+
+    @Transactional
+    public Payment refund(Long paymentId, String merchantId, String reason) {
+        Payment payment = paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new PaymentNotFoundException(paymentId));
+
+        if (!payment.getMerchantId().equals(merchantId)) {
+            throw new MerchantMismatchException(paymentId);
+        }
+
+        if (payment.getStatus() != PaymentStatus.COMPLETED) {
+            throw new InvalidPaymentStateException(paymentId, PaymentStatus.COMPLETED, payment.getStatus());
+        }
+
+        payment.markRefunded();
+        Payment saved = paymentRepository.save(payment);
+
+        ledgerEntryRepository.save(new LedgerEntry(payment, "cash", "merchant_receivable", payment.getAmount()));
+
+        recordEvent(saved, "PAYMENT_REFUNDED", Map.of(
+                "paymentId", saved.getId(),
+                "merchantId", saved.getMerchantId(),
+                "amount", saved.getAmount(),
+                "status", saved.getStatus().name(),
+                "reason", reason
+        ));
+        return saved;
+    }
+
+    private void recordEvent(Payment payment, String eventType, Map<String, Object> payload) {
+        try {
+            String body = objectMapper.writeValueAsString(payload);
+            outboxEventRepository.save(new OutboxEvent(
+                    "PAYMENT",
+                    payment.getId(),
+                    eventType,
+                    body
+            ));
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Failed to serialize event payload", ex);
+        }
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/web/AuthorizePaymentRequest.java
+++ b/src/main/java/com/hecto/payments/paymentservice/web/AuthorizePaymentRequest.java
@@ -1,0 +1,14 @@
+package com.hecto.payments.paymentservice.web;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record AuthorizePaymentRequest(
+        @NotBlank @Size(max = 32) String merchantId,
+        @NotNull @Min(1) Long amount,
+        @NotBlank @Size(min = 3, max = 3) String currency,
+        @NotBlank @Size(max = 64) String idempotencyKey
+) {
+}

--- a/src/main/java/com/hecto/payments/paymentservice/web/CapturePaymentRequest.java
+++ b/src/main/java/com/hecto/payments/paymentservice/web/CapturePaymentRequest.java
@@ -1,0 +1,9 @@
+package com.hecto.payments.paymentservice.web;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CapturePaymentRequest(
+        @NotBlank @Size(max = 32) String merchantId
+) {
+}

--- a/src/main/java/com/hecto/payments/paymentservice/web/PaymentController.java
+++ b/src/main/java/com/hecto/payments/paymentservice/web/PaymentController.java
@@ -1,0 +1,77 @@
+package com.hecto.payments.paymentservice.web;
+
+import com.hecto.payments.paymentservice.exception.DuplicateRequestException;
+import com.hecto.payments.paymentservice.exception.InvalidPaymentStateException;
+import com.hecto.payments.paymentservice.exception.PaymentNotFoundException;
+import com.hecto.payments.paymentservice.exception.MerchantMismatchException;
+import com.hecto.payments.paymentservice.service.PaymentCommandService;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/payments")
+public class PaymentController {
+
+    private final PaymentCommandService paymentCommandService;
+
+    public PaymentController(PaymentCommandService paymentCommandService) {
+        this.paymentCommandService = paymentCommandService;
+    }
+
+    @PostMapping("/authorize")
+    public ResponseEntity<PaymentResponse> authorize(@Valid @RequestBody AuthorizePaymentRequest request) {
+        var payment = paymentCommandService.authorize(
+                request.merchantId(),
+                request.amount(),
+                request.currency(),
+                request.idempotencyKey()
+        );
+        return ResponseEntity.ok(PaymentResponse.from(payment));
+    }
+
+    @PostMapping("/capture/{paymentId}")
+    public ResponseEntity<PaymentResponse> capture(@PathVariable("paymentId") Long paymentId,
+                                                   @Valid @RequestBody CapturePaymentRequest request) {
+        var payment = paymentCommandService.capture(paymentId, request.merchantId());
+        return ResponseEntity.ok(PaymentResponse.from(payment));
+    }
+
+    @PostMapping("/refund/{paymentId}")
+    public ResponseEntity<PaymentResponse> refund(@PathVariable("paymentId") Long paymentId,
+                                                  @Valid @RequestBody RefundPaymentRequest request) {
+        var payment = paymentCommandService.refund(paymentId, request.merchantId(), request.reason());
+        return ResponseEntity.ok(PaymentResponse.from(payment));
+    }
+
+    @ExceptionHandler(DuplicateRequestException.class)
+    public ResponseEntity<ProblemDetailResponse> handleDuplicate(DuplicateRequestException ex) {
+        var body = new ProblemDetailResponse("DUPLICATE_REQUEST", ex.getMessage(),
+                ex.getExistingPayment().getId());
+        return ResponseEntity.status(HttpStatus.CONFLICT).body(body);
+    }
+
+    @ExceptionHandler(PaymentNotFoundException.class)
+    public ResponseEntity<ProblemDetailResponse> handleNotFound(PaymentNotFoundException ex) {
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(new ProblemDetailResponse("PAYMENT_NOT_FOUND", ex.getMessage(), null));
+    }
+
+    @ExceptionHandler(InvalidPaymentStateException.class)
+    public ResponseEntity<ProblemDetailResponse> handleInvalidState(InvalidPaymentStateException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ProblemDetailResponse("INVALID_STATE", ex.getMessage(), null));
+    }
+
+    @ExceptionHandler(MerchantMismatchException.class)
+    public ResponseEntity<ProblemDetailResponse> handleMerchantMismatch(MerchantMismatchException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ProblemDetailResponse("MERCHANT_MISMATCH", ex.getMessage(), null));
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/web/PaymentResponse.java
+++ b/src/main/java/com/hecto/payments/paymentservice/web/PaymentResponse.java
@@ -1,0 +1,27 @@
+package com.hecto.payments.paymentservice.web;
+
+import com.hecto.payments.paymentservice.domain.Payment;
+import com.hecto.payments.paymentservice.domain.PaymentStatus;
+import java.time.Instant;
+
+public record PaymentResponse(
+        Long paymentId,
+        String merchantId,
+        Long amount,
+        String currency,
+        PaymentStatus status,
+        Instant requestedAt,
+        Instant updatedAt
+) {
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(
+                payment.getId(),
+                payment.getMerchantId(),
+                payment.getAmount(),
+                payment.getCurrency(),
+                payment.getStatus(),
+                payment.getRequestedAt(),
+                payment.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/hecto/payments/paymentservice/web/ProblemDetailResponse.java
+++ b/src/main/java/com/hecto/payments/paymentservice/web/ProblemDetailResponse.java
@@ -1,0 +1,8 @@
+package com.hecto.payments.paymentservice.web;
+
+public record ProblemDetailResponse(
+        String code,
+        String message,
+        Long paymentId
+) {
+}

--- a/src/main/java/com/hecto/payments/paymentservice/web/RefundPaymentRequest.java
+++ b/src/main/java/com/hecto/payments/paymentservice/web/RefundPaymentRequest.java
@@ -1,0 +1,10 @@
+package com.hecto.payments.paymentservice.web;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record RefundPaymentRequest(
+        @NotBlank @Size(max = 32) String merchantId,
+        @NotBlank @Size(max = 128) String reason
+) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,16 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:paydb;DB_CLOSE_DELAY=-1
+    driver-class-name: org.h2.Driver
+    username: sa
+    password: ''
+  jpa:
+    hibernate:
+      ddl-auto: update
+    show-sql: false
+    properties:
+      hibernate:
+        format_sql: true
+  h2:
+    console:
+      enabled: true

--- a/src/test/java/com/hecto/payments/paymentservice/PaymentControllerTest.java
+++ b/src/test/java/com/hecto/payments/paymentservice/PaymentControllerTest.java
@@ -1,0 +1,89 @@
+package com.hecto.payments.paymentservice;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class PaymentControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @Test
+    void authorizeCreatesPayment() throws Exception {
+        var request = new AuthorizeRequest("M100", 10_000L, "KRW", "idem-1");
+
+        mockMvc.perform(post("/payments/authorize")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.merchantId").value("M100"))
+                .andExpect(jsonPath("$.status").value("REQUESTED"));
+    }
+
+    @Test
+    void duplicateAuthorizationReturnsConflict() throws Exception {
+        var request = new AuthorizeRequest("M101", 5_000L, "KRW", "dup-key");
+        mockMvc.perform(post("/payments/authorize")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/payments/authorize")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value("DUPLICATE_REQUEST"))
+                .andExpect(jsonPath("$.paymentId").isNumber());
+    }
+
+    @Test
+    void captureAndRefundTransitionsPayment() throws Exception {
+        var authorizeRequest = new AuthorizeRequest("M102", 7_500L, "KRW", "idem-2");
+        MvcResult result = mockMvc.perform(post("/payments/authorize")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(authorizeRequest)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        var response = objectMapper.readTree(result.getResponse().getContentAsString());
+        long paymentId = response.get("paymentId").asLong();
+
+        var captureRequest = new CaptureRequest("M102");
+        mockMvc.perform(post("/payments/capture/" + paymentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(captureRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("COMPLETED"));
+
+        var refundRequest = new RefundRequest("M102", "customer cancellation");
+        mockMvc.perform(post("/payments/refund/" + paymentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(refundRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REFUNDED"));
+    }
+
+    private record AuthorizeRequest(String merchantId, Long amount, String currency, String idempotencyKey) {
+    }
+
+    private record CaptureRequest(String merchantId) {
+    }
+
+    private record RefundRequest(String merchantId, String reason) {
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold a Spring Boot payment-service module with REST endpoints for authorization, capture, and refund
- persist payment, ledger, and outbox records via Spring Data JPA with idempotency and basic validations
- add MockMvc integration tests covering happy path, duplicate idempotency handling, and full capture/refund flow
- document build instructions and available endpoints in the README

## Testing
- mvn test

------
https://chatgpt.com/codex/tasks/task_e_68db24c34b00832ca1b3d40a5a5aadf1