### PR TITLE
Add Spring Boot actuator starter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
     implementation "org.springframework.boot:spring-boot-starter-validation"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+    implementation "org.springframework.boot:spring-boot-starter-actuator"
 
     runtimeOnly "com.h2database:h2"
 


### PR DESCRIPTION
## Summary
- add the Spring Boot actuator starter so health and other management endpoints are available

## Testing
- ./gradlew bootRun
- curl -s http://localhost:8080/actuator/health

------
https://chatgpt.com/codex/tasks/task_e_68db60025a20832caabe05e99309a38a